### PR TITLE
Implements the short_name change for SUMA 5.1

### DIFF
--- a/suse_cloud_image_name_parser/suse_cloud_image_name.py
+++ b/suse_cloud_image_name_parser/suse_cloud_image_name.py
@@ -529,8 +529,12 @@ class SUSECloudImageName:  # pylint: disable=R0904
         if self.is_sap:
             return 'SLES-SAP'
         if self.is_suma and self.suma_type == 'server':
+            if float(self.product_version) >= 5.1:
+                return 'multi-linux-manager'
             return 'SUSE-MANAGER'
         if self.is_suma and self.suma_type == 'proxy':
+            if float(self.product_version) >= 5.1:
+                return 'multi-linux-manager-proxy'
             return 'SUSE-MANAGER-PROXY'
         if self.is_leap:
             return 'OPENSUSE-LEAP'


### PR DESCRIPTION


That param is used in mashhouse for generating the release_notes URL.

For Multi-Linux manager 5.1 the release notes URLs are:
https://www.suse.com/releasenotes/x86_64/multi-linux-manager-proxy/5.1/index.html
https://www.suse.com/releasenotes/x86_64/multi-linux-manager/5.1/index.html

Thus, we need this change in that field.