### PR TITLE
Changes the product_version from `16-0` to `16.0` for sles >= 16.x

### DIFF
--- a/suse_cloud_image_name_parser/suse_cloud_image_name.py
+++ b/suse_cloud_image_name_parser/suse_cloud_image_name.py
@@ -248,9 +248,17 @@ class SUSECloudImageName:  # pylint: disable=R0904
         version = []
         result = None
         version.append(self.product_major)
-        if self.is_sle_server or self.is_hpc:
+        if any([
+            self.is_hpc,
+            self.is_sle_server and self.product_major_int <= 15
+        ]):
             joiner = '-'
-        elif self.is_suma or self.is_leap or self.is_micro:
+        elif any([
+            self.is_suma,
+            self.is_leap,
+            self.is_micro,
+            self.is_sle_server and self.product_major_int > 15
+        ]):
             joiner = '.'
 
         if self.product_minor:


### PR DESCRIPTION

We already have `product_version_dashed` if we need `16-0` but there's no easy way to get `16.0`