### PR TITLE
Changes the short_name for Micro images

### DIFF
--- a/suse_cloud_image_name_parser/suse_cloud_image_name.py
+++ b/suse_cloud_image_name_parser/suse_cloud_image_name.py
@@ -594,9 +594,7 @@ class SUSECloudImageName:  # pylint: disable=R0904
     def short_name(self):
         """Get short name used for release notes"""
         if self.is_micro:
-            if float(self.product_version) >= 6.0:
-                return 'SL-Micro'
-            return 'SLE-Micro'
+            return 'sle-micro'
         if self.is_hpc:
             return 'sle-hpc'
         if self.is_sap:

--- a/test/test_suse_cloud_image_name.py
+++ b/test/test_suse_cloud_image_name.py
@@ -124,7 +124,7 @@ class TestSUSECloudImageName(object):
                     'is_containerized': False,
                     'created_at': datetime.datetime(2025, 7, 24),
                     'oval_product': 'suse.linux.enterprise.micro.5.3',
-                    'short_name': 'SLE-Micro',
+                    'short_name': 'sle-micro',
                     'is_sles_plus_foo': False,
                     'is_transup': False,
                     'transup': None
@@ -164,7 +164,7 @@ class TestSUSECloudImageName(object):
                     'is_containerized': False,
                     'created_at': datetime.datetime(2025, 7, 24),
                     'oval_product': 'suse.linux.micro.6.0',
-                    'short_name': 'SL-Micro',
+                    'short_name': 'sle-micro',
                     'is_sles_plus_foo': False,
                     'is_transup': False,
                     'transup': None
@@ -525,7 +525,7 @@ class TestSUSECloudImageName(object):
                     'is_containerized': False,
                     'created_at': datetime.datetime(2025, 7, 24),
                     'oval_product': 'suse.linux.micro.6.0',
-                    'short_name': 'SL-Micro',
+                    'short_name': 'sle-micro',
                     'is_sles_plus_foo': False,
                     'is_transup': True,
                     'transup': 'transup',


### PR DESCRIPTION

This change is required to use the release notes from documentation.suse.com site, as all micro release notet use the same `sle-micro` name in the URL.